### PR TITLE
Add detailed documentation for circuit calculations

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,8 @@
+"""Core computational utilities for the RC and RL calculator.
+
+This package contains the pure numerical routines used by different
+front‑ends.  Functions here implement the electrical calculations for series
+RL and RC circuits and deliberately avoid any user‑interface concerns.
+"""
+
+# The public API is exposed via ``core.calculations``.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,6 @@
+"""Graphical user interface for the RC and RL calculator.
+
+Modules in this package provide the Tkinter based application that wraps the
+core calculation routines.  It handles user interaction and presents circuit
+results visually.
+"""


### PR DESCRIPTION
## Summary
- Expand `calculate_derived_reactance_params` docstring with algorithm and validation details
- Document `calculate_series_ac_circuit` with parameter descriptions and error handling
- Add module-level docstrings for new `core` and `gui` packages

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68960520dfb8832ab1ac0de8030fdaca