### PR TITLE
Add platform-specific entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,8 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Platform-specific artifacts
+.DS_Store
+Thumbs.db
+Desktop.ini


### PR DESCRIPTION
## Summary
- extend root .gitignore to cover platform-specific files

## Testing
- `pre-commit run --files .gitignore`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896098cd930832ab5c715a168107571