### PR TITLE
Add Sphinx documentation and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build docs
+        run: |
+          sphinx-apidoc -o docs/api .
+          sphinx-build -b html docs docs/_build/html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -1,0 +1,21 @@
+core package
+============
+
+Submodules
+----------
+
+core.calculations module
+------------------------
+
+.. automodule:: core.calculations
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: core
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/gui.rst
+++ b/docs/api/gui.rst
@@ -1,0 +1,21 @@
+gui package
+===========
+
+Submodules
+----------
+
+gui.app module
+--------------
+
+.. automodule:: gui.app
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: gui
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -1,0 +1,7 @@
+main module
+===========
+
+.. automodule:: main
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,9 @@
+RC-and-RL-Calculator
+====================
+
+.. toctree::
+   :maxdepth: 4
+
+   core
+   gui
+   main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'RC and RL Calculator'
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosummary',
+]
+autosummary_generate = True
+templates_path = ['_templates']
+exclude_patterns = []
+html_theme = 'sphinx_rtd_theme'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+RC and RL Calculator
+====================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api/modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from gui.app import ACCircuitSolverApp
 def main() -> None:
     """Launch the AC Circuit Solver GUI."""
     root = tk.Tk()
-    app = ACCircuitSolverApp(root)
+    ACCircuitSolverApp(root)
     root.mainloop()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 numpy
 matplotlib
 tk
+
+sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
## Summary
- Set up Sphinx-based documentation with autodoc, napoleon, and autosummary
- Auto-generate API reference from docstrings
- Deploy documentation to GitHub Pages via workflow

## Testing
- `sphinx-build -b html docs docs/_build/html`
- `pre-commit run --all-files`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961159f320832ab57a69f6e69a2270