### PR TITLE
Configure test coverage with pytest-cov

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["E", "F"]
 ignore = ["E501"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=rc_rl_calculator.core --cov=rc_rl_calculator.gui"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 matplotlib
 tk
+pytest-cov


### PR DESCRIPTION
## Summary
- include pytest-cov in project requirements
- set pytest addopts for coverage of core and gui modules

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961151f164832a9cfa188c00d7c22a