### PR TITLE
Add CLI tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install .
+          pip install pre-commit pytest-cov
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        run: pytest
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RC and RL Calculator
 
+[![codecov](https://codecov.io/gh/OWNER/RC-and-RL-Calculator/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/RC-and-RL-Calculator)
+
 A Python GUI and CLI application for exploring series **RL** (resistor–inductor) and **RC** (resistor–capacitor) circuits. It computes key electrical parameters and can plot voltage/current waveforms and phasor diagrams.
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,4 @@ select = ["E", "F"]
 ignore = ["E501"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=rc_rl_calculator.core --cov=rc_rl_calculator.gui"
+addopts = "--cov=rc_rl_calculator.cli --cov=rc_rl_calculator.core --cov-report=term-missing --cov-report=xml --cov-fail-under=65"

--- a/rc_rl_calculator/main.py
+++ b/rc_rl_calculator/main.py
@@ -5,7 +5,7 @@ from rc_rl_calculator.gui.app import ACCircuitSolverApp
 def main() -> None:
     """Launch the AC Circuit Solver GUI."""
     root = tk.Tk()
-    app = ACCircuitSolverApp(root)
+    _app = ACCircuitSolverApp(root)
     root.mainloop()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the package root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from rc_rl_calculator.cli import main
+from rc_rl_calculator.core.calculations import calculate_series_ac_circuit
+
+
+def parse_output(output: str) -> dict:
+    """Convert CLI output into a dictionary of values."""
+    result = {}
+    for line in output.strip().splitlines():
+        key, value = line.split(": ", 1)
+        try:
+            result[key] = float(value)
+        except ValueError:
+            result[key] = value
+    return result
+
+
+def test_cli_output_matches_calculation(capsys):
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "100",
+        "--component",
+        "1e-6",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RC",
+    ]
+    main(argv)
+    cli_result = parse_output(capsys.readouterr().out)
+
+    expected = calculate_series_ac_circuit(10.0, 100.0, 1e-6, None, 1000.0, "RC")
+
+    assert cli_result["Z"] == pytest.approx(expected["Z"])
+    assert cli_result["I_rms"] == pytest.approx(expected["I_rms"])
+    assert cli_result["phi"] == pytest.approx(expected["phi"])


### PR DESCRIPTION
## Summary
- add a regression test for CLI `main` comparing output to core calculations
- enforce coverage using pytest-cov and fail under 65%
- run linting, tests, and Codecov upload in CI

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689622f347e8832abb3c32e962019438