### PR TITLE
Add RLC circuit analysis and executable build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/OWNER/RC-and-RL-Calculator/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/RC-and-RL-Calculator)
 
-A Python GUI and CLI application for exploring series **RL** (resistor–inductor) and **RC** (resistor–capacitor) circuits. It computes key electrical parameters and can plot voltage/current waveforms and phasor diagrams.
+A Python GUI and CLI application for exploring series **RL** (resistor–inductor) and **RC** (resistor–capacitor) circuits. It computes key electrical parameters and can plot voltage/current waveforms and phasor diagrams. Recent updates also add support for **RLC** circuits in both series and parallel configurations via the CLI.
 
 ## Installation
 1. Ensure Python 3.11+ is installed.
@@ -49,6 +49,18 @@ Example calculation for a series RC circuit:
 rc-rl-calc --voltage 120 --resistance 100 --component 1e-6 --frequency 60 --circuit RC
 ```
 
+Series RLC example:
+
+```bash
+rc-rl-calc --voltage 10 --resistance 10 --inductance 0.05 --capacitance 1e-6 --frequency 1000 --circuit RLC_SERIES
+```
+
+Parallel RLC example:
+
+```bash
+rc-rl-calc --voltage 10 --resistance 100 --inductance 0.1 --capacitance 1e-5 --frequency 1000 --circuit RLC_PARALLEL
+```
+
 ## Examples
 
 Example scripts demonstrating the library are available in the
@@ -65,6 +77,25 @@ Derives the missing value among component magnitude, reactance and angular frequ
 
 ### `calculate_series_ac_circuit(V_rms, R, component_val, reactance_val, f, circuit_type)`
 Computes parameters for a series RL or RC circuit. Requires the RMS source voltage, resistance and any two of component value, reactance or frequency. Returns a dictionary containing impedance, phase angle, currents and voltages.
+
+### `calculate_series_rlc_circuit(V_rms, R, L, C, f)`
+Calculates impedance, phase angle and component voltages for a series RLC circuit.
+Both inductance and capacitance must be greater than zero.
+
+### `calculate_parallel_rlc_circuit(V_rms, R, L, C, f)`
+Determines total impedance, phase angle and branch currents for a parallel RLC circuit.
+Both inductance and capacitance must be greater than zero.
+
+## Building an Executable
+
+To create a standalone Windows executable for the GUI, install the optional build dependencies and run the helper script:
+
+```bash
+pip install .[build]
+python build_exe.py
+```
+
+The resulting `rc_rl_calculator.exe` will be placed inside the `dist` directory and launched automatically.
 
 ## Contributing
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,42 @@
+"""Build and launch a standalone executable for the GUI using PyInstaller.
+
+Run:
+    python build_exe.py
+
+Requires the 'pyinstaller' package. The resulting executable will be
+located in the 'dist' directory and launched automatically.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import PyInstaller.__main__
+
+
+def build() -> Path:
+    PyInstaller.__main__.run(
+        [
+            "src/rc_rl_calculator/main.py",
+            "--name",
+            "rc_rl_calculator",
+            "--onefile",
+            "--windowed",
+        ]
+    )
+    exe = Path("dist") / (
+        "rc_rl_calculator.exe" if os.name == "nt" else "rc_rl_calculator"
+    )
+    return exe
+
+
+def main() -> None:
+    exe = build()
+    if exe.exists():
+        subprocess.run([str(exe)])
+    else:
+        raise FileNotFoundError(f"Executable not found: {exe}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "ttkbootstrap",
 ]
 
+[project.optional-dependencies]
+build = ["pyinstaller"]
+
 [project.scripts]
 "rc-rl-calc" = "rc_rl_calculator.cli:main"
 "rc-rl-gui" = "rc_rl_calculator.main:main"

--- a/src/rc_rl_calculator/cli.py
+++ b/src/rc_rl_calculator/cli.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import argparse
 from typing import Iterable, Optional
 
-from rc_rl_calculator.core.calculations import calculate_series_ac_circuit
+from rc_rl_calculator.core.calculations import (
+    calculate_parallel_rlc_circuit,
+    calculate_series_ac_circuit,
+    calculate_series_rlc_circuit,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
     """Create the argument parser for the CLI."""
     parser = argparse.ArgumentParser(
         description=(
-            "Solve series RC or RL circuits given voltage, resistance and "
-            "two of component value, reactance or frequency."
+            "Solve series RL/RC or series/parallel RLC circuits given "
+            "the necessary parameters."
         )
     )
     parser.add_argument(
@@ -39,13 +43,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Reactance magnitude in ohms",
     )
     parser.add_argument(
+        "--inductance",
+        type=float,
+        help="Inductance in henries for RLC circuits",
+    )
+    parser.add_argument(
+        "--capacitance",
+        type=float,
+        help="Capacitance in farads for RLC circuits",
+    )
+    parser.add_argument(
         "--frequency",
         type=float,
         help="Frequency in hertz",
     )
     parser.add_argument(
         "--circuit",
-        choices=["RL", "RC"],
+        choices=["RL", "RC", "RLC_SERIES", "RLC_PARALLEL"],
         required=True,
         help="Circuit type to solve",
     )
@@ -57,14 +71,44 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    result = calculate_series_ac_circuit(
-        V_rms=args.voltage,
-        R=args.resistance,
-        component_val=args.component,
-        reactance_val=args.reactance,
-        f=args.frequency,
-        circuit_type=args.circuit,
-    )
+    if args.circuit in {"RL", "RC"}:
+        result = calculate_series_ac_circuit(
+            V_rms=args.voltage,
+            R=args.resistance,
+            component_val=args.component,
+            reactance_val=args.reactance,
+            f=args.frequency,
+            circuit_type=args.circuit,
+        )
+    else:
+        if (
+            args.inductance is None
+            or args.capacitance is None
+            or args.frequency is None
+        ):
+            parser.error(
+                "--inductance, --capacitance and --frequency are required for RLC circuits"
+            )
+        if args.inductance <= 0 or args.capacitance <= 0 or args.frequency <= 0:
+            parser.error(
+                "--inductance, --capacitance and --frequency must be greater than zero for RLC circuits"
+            )
+        if args.circuit == "RLC_SERIES":
+            result = calculate_series_rlc_circuit(
+                V_rms=args.voltage,
+                R=args.resistance,
+                L=args.inductance,
+                C=args.capacitance,
+                f=args.frequency,
+            )
+        else:
+            result = calculate_parallel_rlc_circuit(
+                V_rms=args.voltage,
+                R=args.resistance,
+                L=args.inductance,
+                C=args.capacitance,
+                f=args.frequency,
+            )
 
     for key, value in result.items():
         print(f"{key}: {value}")

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -9,6 +9,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from rc_rl_calculator.core.calculations import (
     calculate_derived_reactance_params,
     calculate_series_ac_circuit,
+    calculate_parallel_rlc_circuit,
+    calculate_series_rlc_circuit,
 )
 
 
@@ -79,3 +81,23 @@ def test_negative_voltage_raises(expect_value_error):
 
 def test_negative_frequency_raises(expect_value_error):
     expect_value_error(calculate_series_ac_circuit, 1.0, 10.0, None, None, -1.0, "RL")
+
+
+def test_series_rlc_basic(approx_cmp):
+    result = calculate_series_rlc_circuit(10.0, 10.0, 0.05, 1e-6, 1000.0)
+    assert result["Z"] == approx_cmp(155.3266, rel=1e-4)
+    assert result["phi"] == approx_cmp(86.3087, rel=1e-4)
+
+
+def test_parallel_rlc_basic(approx_cmp):
+    result = calculate_parallel_rlc_circuit(10.0, 100.0, 0.1, 10e-6, 1000.0)
+    assert result["Z"] == approx_cmp(16.1157, rel=1e-4)
+    assert result["phi"] == approx_cmp(-80.7259, rel=1e-4)
+
+
+def test_series_rlc_zero_inductance_raises(expect_value_error):
+    expect_value_error(calculate_series_rlc_circuit, 10.0, 10.0, 0.0, 1e-6, 1000.0)
+
+
+def test_parallel_rlc_zero_capacitance_raises(expect_value_error):
+    expect_value_error(calculate_parallel_rlc_circuit, 10.0, 100.0, 0.1, 0.0, 1000.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,11 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from rc_rl_calculator.cli import main
-from rc_rl_calculator.core.calculations import calculate_series_ac_circuit
+from rc_rl_calculator.core.calculations import (
+    calculate_parallel_rlc_circuit,
+    calculate_series_ac_circuit,
+    calculate_series_rlc_circuit,
+)
 
 
 def parse_output(output: str) -> dict:
@@ -43,3 +47,85 @@ def test_cli_output_matches_calculation(capsys):
     assert cli_result["Z"] == pytest.approx(expected["Z"])
     assert cli_result["I_rms"] == pytest.approx(expected["I_rms"])
     assert cli_result["phi"] == pytest.approx(expected["phi"])
+
+
+def test_cli_rlc_series_matches_calculation(capsys):
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "10",
+        "--inductance",
+        "0.05",
+        "--capacitance",
+        "1e-6",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RLC_SERIES",
+    ]
+    main(argv)
+    cli_result = parse_output(capsys.readouterr().out)
+    expected = calculate_series_rlc_circuit(10.0, 10.0, 0.05, 1e-6, 1000.0)
+    assert cli_result["Z"] == pytest.approx(expected["Z"])
+    assert cli_result["phi"] == pytest.approx(expected["phi"])
+
+
+def test_cli_rlc_parallel_matches_calculation(capsys):
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "100",
+        "--inductance",
+        "0.1",
+        "--capacitance",
+        "1e-5",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RLC_PARALLEL",
+    ]
+    main(argv)
+    cli_result = parse_output(capsys.readouterr().out)
+    expected = calculate_parallel_rlc_circuit(10.0, 100.0, 0.1, 1e-5, 1000.0)
+    assert cli_result["Z"] == pytest.approx(expected["Z"])
+    assert cli_result["phi"] == pytest.approx(expected["phi"])
+
+
+def test_cli_rlc_zero_inductance_errors():
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "10",
+        "--inductance",
+        "0",
+        "--capacitance",
+        "1e-6",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RLC_SERIES",
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
+
+
+def test_cli_rlc_zero_capacitance_errors():
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "10",
+        "--inductance",
+        "0.05",
+        "--capacitance",
+        "0",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RLC_SERIES",
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)


### PR DESCRIPTION
## Summary
- document that inductance and capacitance must be greater than zero for RLC calculations and note automatic executable launch
- validate CLI RLC options require positive inductance, capacitance, and frequency
- enforce positive inductance, capacitance, and frequency in series and parallel RLC computations

## Testing
- `pre-commit run --files README.md build_exe.py src/rc_rl_calculator/cli.py src/rc_rl_calculator/core/calculations.py tests/test_calculations.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689631276fa4832a930f4097019e90f3