### PR TITLE
Add series/parallel L and C equivalent calculators

### DIFF
--- a/src/rc_rl_calculator/core/calculations.py
+++ b/src/rc_rl_calculator/core/calculations.py
@@ -1,10 +1,84 @@
 import math
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 import cmath
 
 SQRT_2 = math.sqrt(2)
 TWO_PI = 2 * math.pi
 PI_OVER_2 = math.pi / 2
+
+
+def equivalent_capacitance(capacitors: Iterable[float], connection: str) -> float:
+    """Compute the equivalent capacitance of multiple capacitors.
+
+    Parameters
+    ----------
+    capacitors : Iterable[float]
+        Capacitor values in farads. All values must be positive.
+    connection : str
+        ``"series"`` or ``"parallel"`` to select the configuration.
+
+    Returns
+    -------
+    float
+        The equivalent capacitance in farads.
+
+    Raises
+    ------
+    ValueError
+        If an invalid connection type is supplied or capacitor values are
+        non‑positive.
+    """
+
+    caps = list(capacitors)
+    if not caps:
+        raise ValueError("At least one capacitance value must be provided.")
+    if any(c <= 0 for c in caps):
+        raise ValueError("Capacitance values must be positive.")
+
+    connection = connection.lower()
+    if connection == "parallel":
+        return sum(caps)
+    if connection == "series":
+        return 1.0 / sum(1.0 / c for c in caps)
+    raise ValueError("connection must be 'series' or 'parallel'.")
+
+
+def equivalent_inductance(inductors: Iterable[float], connection: str) -> float:
+    """Compute the equivalent inductance of multiple inductors.
+
+    Parameters
+    ----------
+    inductors : Iterable[float]
+        Inductor values in henries. All values must be non‑negative.
+    connection : str
+        ``"series"`` or ``"parallel"`` to select the configuration.
+
+    Returns
+    -------
+    float
+        The equivalent inductance in henries.
+
+    Raises
+    ------
+    ValueError
+        If an invalid connection type is supplied or inductance values are
+        negative.
+    """
+
+    inds = list(inductors)
+    if not inds:
+        raise ValueError("At least one inductance value must be provided.")
+    if any(l < 0 for l in inds):
+        raise ValueError("Inductance values must be non-negative.")
+
+    connection = connection.lower()
+    if connection == "series":
+        return sum(inds)
+    if connection == "parallel":
+        if any(l == 0 for l in inds):
+            return 0.0
+        return 1.0 / sum(1.0 / l for l in inds)
+    raise ValueError("connection must be 'series' or 'parallel'.")
 
 
 def calculate_derived_reactance_params(

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -11,6 +11,8 @@ from rc_rl_calculator.core.calculations import (
     calculate_series_ac_circuit,
     calculate_parallel_rlc_circuit,
     calculate_series_rlc_circuit,
+    equivalent_capacitance,
+    equivalent_inductance,
 )
 
 
@@ -93,3 +95,28 @@ def test_parallel_rlc_basic(approx_cmp):
     result = calculate_parallel_rlc_circuit(10.0, 100.0, 0.1, 10e-6, 1000.0)
     assert result["Z"] == approx_cmp(16.1157, rel=1e-4)
     assert result["phi"] == approx_cmp(-80.7259, rel=1e-4)
+
+
+# Tests for equivalent capacitance and inductance
+
+
+def test_equivalent_capacitance(approx_cmp):
+    caps = [1e-6, 2e-6, 3e-6]
+    assert equivalent_capacitance(caps, "parallel") == approx_cmp(6e-6)
+    series_expected = 1 / (1 / 1e-6 + 1 / 2e-6 + 1 / 3e-6)
+    assert equivalent_capacitance(caps, "series") == approx_cmp(series_expected)
+
+
+def test_equivalent_inductance(approx_cmp):
+    inds = [1e-3, 2e-3, 3e-3]
+    assert equivalent_inductance(inds, "series") == approx_cmp(6e-3)
+    parallel_expected = 1 / (1 / 1e-3 + 1 / 2e-3 + 1 / 3e-3)
+    assert equivalent_inductance(inds, "parallel") == approx_cmp(parallel_expected)
+
+
+def test_equivalent_capacitance_invalid(expect_value_error):
+    expect_value_error(equivalent_capacitance, [1e-6, -2e-6], "series")
+
+
+def test_equivalent_inductance_invalid(expect_value_error):
+    expect_value_error(equivalent_inductance, [1e-3, -2e-3], "parallel")


### PR DESCRIPTION
## Summary
- add `equivalent_capacitance` and `equivalent_inductance` helpers for computing series and parallel combinations
- validate inputs and support 0-ohm/henry edge cases
- cover new helpers with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963f24cc88832a92d0e17ac3fd81cf