### PR TITLE
Handle shorted branches in parallel RLC

### DIFF
--- a/src/rc_rl_calculator/core/calculations.py
+++ b/src/rc_rl_calculator/core/calculations.py
@@ -479,6 +479,34 @@ def calculate_parallel_rlc_circuit(
     omega = TWO_PI * f
     X_L = omega * L
     X_C = 1.0 / (omega * C)
+    if R == 0 or L == 0 or X_L == 0:
+        Z_total = complex(0.0, 0.0)
+        Z = 0.0
+        phi = 0.0
+        I_rms = float("inf") if V_rms > 0 else 0.0
+        I_rms_R = float("inf") if R == 0 else V_rms / R
+        I_rms_L = float("inf") if L == 0 or X_L == 0 else V_rms / X_L
+        I_rms_C = V_rms / X_C if X_C != 0 else float("inf")
+        V_peak = V_rms * SQRT_2
+        I_peak = float("inf") if I_rms == float("inf") else I_rms * SQRT_2
+        return {
+            "V_rms": V_rms,
+            "R": R,
+            "L": L,
+            "C": C,
+            "f": f,
+            "omega": omega,
+            "X_L": X_L,
+            "X_C": X_C,
+            "Z": Z,
+            "phi": phi,
+            "I_rms": I_rms,
+            "I_peak": I_peak,
+            "I_rms_R": I_rms_R,
+            "I_rms_L": I_rms_L,
+            "I_rms_C": I_rms_C,
+            "V_peak": V_peak,
+        }
 
     Z_R = complex(R, 0)
     Z_L = complex(0, X_L)

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -97,6 +97,20 @@ def test_parallel_rlc_basic(approx_cmp):
     assert result["phi"] == approx_cmp(-80.7259, rel=1e-4)
 
 
+def test_parallel_rlc_zero_inductance_short():
+    result = calculate_parallel_rlc_circuit(5.0, 10.0, 0.0, 1e-6, 1000.0)
+    assert result["Z"] == 0.0
+    assert result["I_rms"] == float("inf")
+    assert result["I_rms_L"] == float("inf")
+
+
+def test_parallel_rlc_zero_resistance_short():
+    result = calculate_parallel_rlc_circuit(5.0, 0.0, 0.1, 1e-6, 1000.0)
+    assert result["Z"] == 0.0
+    assert result["I_rms"] == float("inf")
+    assert result["I_rms_R"] == float("inf")
+
+
 # Tests for equivalent capacitance and inductance
 
 


### PR DESCRIPTION
## Summary
- Treat zero-ohm resistor or inductor branches as shorts in `calculate_parallel_rlc_circuit`
- Mark shorted branch currents as infinite and skip further impedance calculations
- Test R=0 and L=0 scenarios to ensure zero impedance and infinite current without exceptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964bc99cd4832a84c85b8575693ea3