### PR TITLE
Handle CLI errors gracefully

### DIFF
--- a/src/rc_rl_calculator/cli.py
+++ b/src/rc_rl_calculator/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from typing import Iterable, Optional
+import sys
 
 from rc_rl_calculator.core.calculations import (
     calculate_parallel_rlc_circuit,
@@ -71,43 +72,47 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    if args.circuit in {"RL", "RC"}:
-        result = calculate_series_ac_circuit(
-            V_rms=args.voltage,
-            R=args.resistance,
-            component_val=args.component,
-            reactance_val=args.reactance,
-            f=args.frequency,
-            circuit_type=args.circuit,
-        )
-    else:
-        if (
-            args.inductance is None
-            or args.capacitance is None
-            or args.frequency is None
-        ):
-            parser.error(
-                "--inductance, --capacitance and --frequency are required for RLC circuits"
-            )
-        if args.circuit == "RLC_SERIES":
-            result = calculate_series_rlc_circuit(
+    try:
+        if args.circuit in {"RL", "RC"}:
+            result = calculate_series_ac_circuit(
                 V_rms=args.voltage,
                 R=args.resistance,
-                L=args.inductance,
-                C=args.capacitance,
+                component_val=args.component,
+                reactance_val=args.reactance,
                 f=args.frequency,
+                circuit_type=args.circuit,
             )
         else:
-            result = calculate_parallel_rlc_circuit(
-                V_rms=args.voltage,
-                R=args.resistance,
-                L=args.inductance,
-                C=args.capacitance,
-                f=args.frequency,
-            )
+            if (
+                args.inductance is None
+                or args.capacitance is None
+                or args.frequency is None
+            ):
+                parser.error(
+                    "--inductance, --capacitance and --frequency are required for RLC circuits"
+                )
+            if args.circuit == "RLC_SERIES":
+                result = calculate_series_rlc_circuit(
+                    V_rms=args.voltage,
+                    R=args.resistance,
+                    L=args.inductance,
+                    C=args.capacitance,
+                    f=args.frequency,
+                )
+            else:
+                result = calculate_parallel_rlc_circuit(
+                    V_rms=args.voltage,
+                    R=args.resistance,
+                    L=args.inductance,
+                    C=args.capacitance,
+                    f=args.frequency,
+                )
 
-    for key, value in result.items():
-        print(f"{key}: {value}")
+        for key, value in result.items():
+            print(f"{key}: {value}")
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,3 +91,24 @@ def test_cli_rlc_parallel_matches_calculation(capsys):
     expected = calculate_parallel_rlc_circuit(10.0, 100.0, 0.1, 1e-5, 1000.0)
     assert cli_result["Z"] == pytest.approx(expected["Z"])
     assert cli_result["phi"] == pytest.approx(expected["phi"])
+
+
+def test_cli_invalid_parameters_exit_code_and_message(capsys):
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "-5",
+        "--component",
+        "1e-6",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RC",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        main(argv)
+    assert exc.value.code != 0
+    captured = capsys.readouterr()
+    assert "Resistance (R) must be non-negative." in captured.err
+    assert captured.out == ""


### PR DESCRIPTION
## Summary
- wrap CLI circuit calculation in `try`/`except` to surface parameter errors
- add CLI test asserting invalid arguments produce an error message and non-zero exit

## Testing
- `pre-commit run --files src/rc_rl_calculator/cli.py tests/test_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964cfbb118832a94f3daf203a63e56