### PR TITLE
feat(cli): add json output option

### DIFF
--- a/src/rc_rl_calculator/cli.py
+++ b/src/rc_rl_calculator/cli.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import argparse
-from typing import Iterable, Optional
+import json
 import sys
+from typing import Iterable, Optional
 
 from rc_rl_calculator.core.calculations import (
     calculate_parallel_rlc_circuit,
@@ -64,6 +65,11 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Circuit type to solve",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
     return parser
 
 
@@ -108,8 +114,11 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
                     f=args.frequency,
                 )
 
-        for key, value in result.items():
-            print(f"{key}: {value}")
+        if args.json:
+            print(json.dumps(result))
+        else:
+            for key, value in result.items():
+                print(f"{key}: {value}")
     except ValueError as exc:
         print(exc, file=sys.stderr)
         sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -112,3 +113,25 @@ def test_cli_invalid_parameters_exit_code_and_message(capsys):
     captured = capsys.readouterr()
     assert "Resistance (R) must be non-negative." in captured.err
     assert captured.out == ""
+
+
+def test_cli_outputs_json_when_flag_used(capsys):
+    argv = [
+        "--voltage",
+        "10",
+        "--resistance",
+        "100",
+        "--component",
+        "1e-6",
+        "--frequency",
+        "1000",
+        "--circuit",
+        "RC",
+        "--json",
+    ]
+    main(argv)
+    output = capsys.readouterr().out
+    result = json.loads(output)
+    expected = calculate_series_ac_circuit(10.0, 100.0, 1e-6, None, 1000.0, "RC")
+    for key, value in expected.items():
+        assert result[key] == pytest.approx(value)


### PR DESCRIPTION
## Summary
- add `--json` flag to CLI to serialize calculation results to JSON
- ensure default CLI behavior remains text output
- test JSON output from CLI when flag is set

## Testing
- `pre-commit run --files src/rc_rl_calculator/cli.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964e0cd58c832aaf363cfa3191003e