### PR TITLE
test: rely on conftest for path setup

### DIFF
--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,10 +1,4 @@
-import os
-import sys
-
 import pytest
-
-# Ensure the package root is on sys.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from rc_rl_calculator.core.calculations import (
     calculate_derived_reactance_params,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,6 @@
 import json
-import os
-import sys
 
 import pytest
-
-# Ensure the package root is on sys.path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from rc_rl_calculator.cli import main
 from rc_rl_calculator.core.calculations import (


### PR DESCRIPTION
## Summary
- remove manual `sys.path` manipulation from tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964f110180832aadc1030fc0147a98