### PR TITLE
Add cross-platform installer build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,32 @@ Calculates impedance, phase angle and component voltages for a series RLC circui
 ### `calculate_parallel_rlc_circuit(V_rms, R, L, C, f)`
 Determines total impedance, phase angle and branch currents for a parallel RLC circuit.
 
-## Building an Executable
+## Building an Installer
 
-To create a standalone Windows executable for the GUI, install the optional
-build dependencies and run the helper script:
+To generate a standalone executable for your platform, install the optional
+dependencies and run the provided console command:
 
 ```bash
-pip install .[build]
-python build_exe.py
+pip install .[installer]
+create-installer
 ```
 
-The script invokes PyInstaller, writes ``rc_rl_calculator.exe`` to the ``dist``
-directory and then automatically launches it. Any build failures or missing
-output files will be reported in the console.
+The resulting file is placed in the ``dist`` directory. Example invocations
+on each supported operating system:
+
+```bash
+# Windows
+pip install .[installer]
+create-installer  # produces dist/rc_rl_calculator.exe
+
+# macOS
+pip install .[installer]
+create-installer  # produces dist/rc_rl_calculator.app
+
+# Linux
+pip install .[installer]
+create-installer  # produces dist/rc_rl_calculator
+```
 
 ## Contributing
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,8 +1,7 @@
-"""Build and run a standalone executable for the GUI using PyInstaller.
+"""Build standalone executables for the GUI using PyInstaller.
 
-Run ``python build_exe.py`` to create ``rc_rl_calculator.exe`` in the
-``dist`` directory and automatically launch it. A clear error message is
-reported if the build fails or the executable cannot be found.
+This module powers the ``create-installer`` console script. It can also be run
+directly to build the executable and launch it immediately.
 
 Requires the :mod:`pyinstaller` package.
 """
@@ -10,37 +9,81 @@ Requires the :mod:`pyinstaller` package.
 from __future__ import annotations
 
 import subprocess
+import platform
 from pathlib import Path
 from typing import Final
 
 import PyInstaller.__main__
 
 
-DIST_DIR: Final = Path("dist")
-EXE_NAME: Final = "rc_rl_calculator.exe"
+APP_NAME: Final = "rc_rl_calculator"
+DEFAULT_DIST_DIR: Final = Path("dist")
 
 
-def build() -> Path:
-    """Run PyInstaller and return the path to the built executable."""
+def build(target: str | None = None, dist_path: Path | None = None) -> Path:
+    """Run PyInstaller and return the path to the built executable.
+
+    Parameters
+    ----------
+    target:
+        Optional target platform (``"windows"``, ``"mac"`` or ``"linux"``). If
+        ``None`` the current operating system is used.
+    dist_path:
+        Directory where the executable should be written. Defaults to
+        :data:`DEFAULT_DIST_DIR`.
+    """
+
+    if target is None:
+        system = platform.system().lower()
+        if system.startswith("win"):
+            target = "windows"
+        elif system == "darwin":
+            target = "mac"
+        else:
+            target = "linux"
+    else:
+        target = target.lower()
+
+    dist_dir = dist_path or DEFAULT_DIST_DIR
+
+    exe_name = APP_NAME
+    if target == "windows":
+        exe_name += ".exe"
+    elif target == "mac":
+        exe_name += ".app"
+
     try:
         PyInstaller.__main__.run(
             [
                 "src/rc_rl_calculator/main.py",
                 "--name",
-                "rc_rl_calculator",
+                APP_NAME,
                 "--onefile",
                 "--windowed",
+                "--distpath",
+                str(dist_dir),
             ]
         )
     except SystemExit as exc:  # pragma: no cover - exercised during manual runs
         code = exc.code if isinstance(exc.code, int) else 1
         raise RuntimeError(f"PyInstaller failed with exit code {code}") from None
 
-    exe_path = DIST_DIR / EXE_NAME
+    exe_path = dist_dir / exe_name
     if not exe_path.is_file():
         raise FileNotFoundError(f"Expected executable not found: {exe_path}")
 
     return exe_path
+
+
+def create_installer() -> None:
+    """CLI entry point that builds an installer for the current platform."""
+    try:
+        exe_path = build()
+    except Exception as exc:  # pragma: no cover - exercised during manual runs
+        print(f"Build failed: {exc}")
+        raise SystemExit(1)
+
+    print(f"Installer written to {exe_path}")
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-build = ["pyinstaller"]
+installer = ["pyinstaller"]
 
 [project.scripts]
 "rc-rl-calc" = "rc_rl_calculator.cli:main"
 "rc-rl-gui" = "rc_rl_calculator.main:main"
+"create-installer" = "build_exe:create_installer"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+py-modules = ["build_exe"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- generalize PyInstaller build helper to support Windows, macOS and Linux targets and expose `create-installer` CLI
- document installer generation and provide dedicated optional dependency group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896e7f76694832aad149885b00ca35d